### PR TITLE
Clarify numbers in StudySpaceResult

### DIFF
--- a/screens/StudySpacesScreen/StudySpaceResult.js
+++ b/screens/StudySpacesScreen/StudySpaceResult.js
@@ -42,7 +42,7 @@ const StudySpaceResult = ({
     <SearchResult
       key={generate()}
       topText={name}
-      bottomText={`${capacityString} (${capacity - occupied} free)`}
+      bottomText={`${capacityString} (${capacity - occupied} seats free)`}
       type="location"
       buttonText="View"
       indicator

--- a/screens/StudySpacesScreen/StudySpaceResult.js
+++ b/screens/StudySpacesScreen/StudySpaceResult.js
@@ -42,7 +42,7 @@ const StudySpaceResult = ({
     <SearchResult
       key={generate()}
       topText={name}
-      bottomText={`${capacityString} (${occupied}/${capacity})`}
+      bottomText={`${capacityString} (${capacity - occupied} free)`}
       type="location"
       buttonText="View"
       indicator


### PR DESCRIPTION
Addresses #2 

Instead of something like (45/300), it's now (45 free).

I didn't think the capacity of the study space was very important => I'm thinking that people would usually already know roughly how big the study space is. So the important data is just how many vacant seats there are.