### PR TITLE
Display breakdown for studyspace rooms

### DIFF
--- a/actions/studyspacesActions.js
+++ b/actions/studyspacesActions.js
@@ -59,10 +59,8 @@ export const fetchSeatInfoFailure = (id, error) => ({
 export const fetchSeatInfos = (token: String, ids: Array) => async (
   dispatch: Function,
 ) => {
-  console.log("setting isFetching to true...");
   await dispatch(setIsFetchingSeatInfo(ids));
   try {
-    console.log("requesting data...");
     const res = await fetch(`${WORKSPACES_URL}/summary`, {
       headers: {
         authorization: `Bearer ${token}`,
@@ -72,7 +70,6 @@ export const fetchSeatInfos = (token: String, ids: Array) => async (
     if (!res.ok) {
       throw new Error(json.error || "There was a problem");
     }
-    console.log("data received");
     return Promise.all(
       ids.map(id => {
         const info = json.content.filter(obj => `${obj.id}` === `${id}`)[0];
@@ -80,12 +77,11 @@ export const fetchSeatInfos = (token: String, ids: Array) => async (
           fetchSeatInfoSuccess(id, {
             occupied: info.occupied,
             capacity: info.total,
+            maps: info.maps,
           }),
         );
       }),
-    ).then(() => {
-      console.log("done");
-    });
+    );
   } catch (error) {
     return Promise.all(
       ids.map(id =>

--- a/reducers/studyspacesReducer.js
+++ b/reducers/studyspacesReducer.js
@@ -32,7 +32,17 @@ export const initialState = {
 const updateStudyspaces = (studyspaces, id, newSpace) => {
   const idx = studyspaces.findIndex(s => s.id === id);
   const newStudyspaces = studyspaces.filter(s => s.id !== id);
-  newStudyspaces.splice(idx, 0, newSpace);
+  const oldStudySpace = studyspaces[idx];
+  newStudyspaces.splice(idx, 0, {
+    ...newSpace,
+    maps: oldStudySpace.maps.map(oldMap => {
+      const newMap = newSpace.maps.filter(m => m.id === oldMap.id)[0];
+      return {
+        ...oldMap,
+        ...newMap,
+      };
+    }),
+  });
   return newStudyspaces;
 };
 
@@ -45,7 +55,7 @@ export default (state = initialState, action = null) => {
       const newStudyspaces = ids.reduce(
         (spaces, s) =>
           updateStudyspaces(spaces, s, {
-            ...state.studyspaces.filter(x => x.id === s),
+            ...state.studyspaces.filter(x => x.id === s)[0],
             isFetchingSeatInfo: true,
             fetchSeatInfoError: "",
           }),

--- a/screens/StudySpaceDetailScreen/LiveSeatingMapList.js
+++ b/screens/StudySpaceDetailScreen/LiveSeatingMapList.js
@@ -33,7 +33,7 @@ class LiveSeatingMapList extends Component {
   render() {
     const { maps } = this.props;
     const hasMaps = maps && Array.isArray(maps) && maps.length > 1;
-    // no need breakdown if only 1 map
+    // No breakdown needed if there is only one map in the survey
     // the map data == the survey data
     if (!hasMaps) {
       return null;

--- a/screens/StudySpaceDetailScreen/LiveSeatingMapList.js
+++ b/screens/StudySpaceDetailScreen/LiveSeatingMapList.js
@@ -1,10 +1,9 @@
+// @flow
 import React, { Component } from "react";
 import { View, StyleSheet } from "react-native";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
-import { SubtitleText } from "../../components/Typography";
-import Button from "../../components/Button";
-import ApiManager from "../../lib/ApiManager";
+import { SubtitleText, BodyText } from "../../components/Typography";
 
 const styles = StyleSheet.create({
   liveSeatingMap: {
@@ -14,39 +13,38 @@ const styles = StyleSheet.create({
 
 class LiveSeatingMapList extends Component {
   static propTypes = {
-    token: PropTypes.string,
-    survey: PropTypes.shape(),
+    maps: PropTypes.arrayOf(PropTypes.shape()),
   };
   static defaultProps = {
-    token: "",
-    survey: null,
+    maps: [],
   };
 
-  static mapStateToProps = state => ({
+  static mapStateToProps = (state: Object) => ({
     token: state.user.token,
   });
   static mapDispatchToProps = () => ({});
+
+  renderMapInfo = ({ id, name, capacity, occupied }) => (
+    <BodyText key={id}>
+      {name}: {capacity - occupied} seats free (total: {capacity})
+    </BodyText>
+  );
+
   render() {
-    const { survey } = this.props;
-    const hasMaps =
-      survey &&
-      survey.maps &&
-      Array.isArray(survey.maps) &&
-      survey.maps.length > 0;
+    const { maps } = this.props;
+    const hasMaps = maps && Array.isArray(maps) && maps.length > 1;
+    // no need breakdown if only 1 map
+    // the map data == the survey data
     if (!hasMaps) {
       return null;
     }
 
-    const { maps } = survey;
+    const mapsList = maps.map(this.renderMapInfo);
 
     return (
       <View style={styles.liveSeatingMap}>
-        <SubtitleText>Live Seating Map</SubtitleText>
-        {maps.map(map => (
-          <Button key={map.id} onPress={this.getLiveSeatMap(map.id)}>
-            {map.name}
-          </Button>
-        ))}
+        <SubtitleText>Breakdown</SubtitleText>
+        {mapsList}
       </View>
     );
   }

--- a/screens/StudySpaceDetailScreen/StudySpaceDetailScreen.js
+++ b/screens/StudySpaceDetailScreen/StudySpaceDetailScreen.js
@@ -7,13 +7,13 @@ import moment from "moment";
 import { connect } from "react-redux";
 import { surveys } from "../../constants/studyspaces";
 import { fetchAverages } from "../../actions/studyspacesActions";
-import Button from "../../components/Button";
 import { Page, Horizontal } from "../../components/Containers";
 import { BodyText, TitleText, SubtitleText } from "../../components/Typography";
 import CapacityChart from "./CapacityChart";
 import LiveIndicator from "./LiveIndicator";
 // import OpeningHours from "./OpeningHours";
 import FavouriteButton from "./FavouriteButton";
+import LiveSeatingMapList from "./LiveSeatingMapList";
 
 const busyText = (
   time = 0,
@@ -122,8 +122,8 @@ class StudySpaceDetailScreen extends Component {
   };
 
   render() {
-    const { id, name, data, capacity, occupied, survey } = this.state;
-    const { isFetchingAverages } = this.state.space;
+    const { id, name, data, capacity, occupied, space } = this.state;
+    const { isFetchingAverages, maps } = space;
     const hour = parseInt(moment().format("HH"), 10);
     return (
       <View style={{ flex: 1 }}>
@@ -160,6 +160,7 @@ class StudySpaceDetailScreen extends Component {
               {busyText(hour, data, occupied, capacity)}
             </BodyText>
           </Horizontal>
+          <LiveSeatingMapList style={styles.liveSeatingMapList} maps={maps} />
           {/* {survey ? (
             <Button onPress={this.navigateToLiveSeatMap}>Live Seat Map</Button>
           ) : null} */}


### PR DESCRIPTION
Addresses #4 and implements the suggested solution.

If the studyspace has only 1 map, the breakdown is not shown (because it would be the same data as displayed elsewhere on the StudySpaceDetailScreen). E.g. Foster Court B24 & B25, Anatomy Hub, etc.


<img src="https://user-images.githubusercontent.com/6523121/52922691-e4110e00-331a-11e9-9d40-adcd7dbc535d.jpg" width="200" />


[Expo link: https://expo.io/@huey/ucl-assistant?release-channel=dev-feature_library_rooms_availability](https://expo.io/@huey/ucl-assistant?release-channel=dev-feature_library_rooms_availability)

