### PR TITLE
Add Card based view to RoomDetail screen

### DIFF
--- a/constants/Colors.js
+++ b/constants/Colors.js
@@ -6,6 +6,7 @@ export default {
   accentColorLight: "#73CCC2",
   textInputBackground: "#eaeaea",
   cardBackground: "#fff",
+  dividerLine: "#808080",
   oldCardBackground: "#f2f2f2",
   buttonBackground: "#4BB3FD",
   disabledButtonBackground: "rgba(152, 153, 160, 1)",

--- a/lib/Shadow.js
+++ b/lib/Shadow.js
@@ -1,0 +1,11 @@
+const Shadow = elevation => ({
+  shadowOpacity: 0.0015 * elevation + 0.18,
+  shadowRadius: 0.54 * elevation,
+  shadowOffset: {
+    height: 0.6 * elevation,
+  },
+  shadowColor: "#000",
+  elevation,
+});
+
+export default Shadow;

--- a/screens/RoomDetailScreen/RoomDetailScreen.js
+++ b/screens/RoomDetailScreen/RoomDetailScreen.js
@@ -24,6 +24,9 @@ const styles = StyleSheet.create({
   },
   booking: {
     marginVertical: 5,
+    backgroundColor: 'white',
+    padding: 20,
+    elevation: 2,
   },
   container: {
     flex: 1,
@@ -37,6 +40,22 @@ const styles = StyleSheet.create({
   },
   equipmentList: {
     marginTop: 20,
+    backgroundColor: 'white',
+    padding: 20,
+    elevation: 2,
+  },
+  cardHeader: {
+    paddingBottom: 5,
+    marginBottom: 5,
+    borderBottomColor: 'grey',
+    borderBottomWidth: 0.5,
+  },
+  bookingHeader: {
+    padding: 20,
+    marginBottom: 5,
+    backgroundColor: '#1B998B',
+    color: 'white',
+    elevation: 2,
   },
   padder: {
     height: 20,
@@ -209,7 +228,7 @@ class RoomDetailScreen extends Component {
           ) : null}
           {equipment.length > 0 ? (
             <View style={styles.equipmentList}>
-              <SubtitleText>In This Room</SubtitleText>
+              <SubtitleText style={styles.cardHeader}>In This Room</SubtitleText>
               {equipment.map(this.renderEquipment)}
             </View>
           ) : null}
@@ -220,7 +239,7 @@ class RoomDetailScreen extends Component {
           ) : null}
           {roombookings.length > 0 ? (
             <View style={styles.bookingList}>
-              <SubtitleText>Bookings Today</SubtitleText>
+              <SubtitleText style={styles.bookingHeader}>Bookings Today</SubtitleText>
               {roombookings.map(this.renderBooking)}
             </View>
           ) : null}

--- a/screens/RoomDetailScreen/RoomDetailScreen.js
+++ b/screens/RoomDetailScreen/RoomDetailScreen.js
@@ -17,16 +17,34 @@ import {
 } from "../../components/Typography";
 import MapStyle from "../../styles/Map";
 import ApiManager from "../../lib/ApiManager";
+import Colors from "../../constants/Colors";
+import Shadow from "../../lib/Shadow";
 
 const styles = StyleSheet.create({
   address: {
     marginVertical: 20,
   },
   booking: {
+    backgroundColor: Colors.cardBackground,
     marginVertical: 5,
-    backgroundColor: 'white',
     padding: 20,
-    elevation: 2,
+    ...Shadow(2),
+  },
+  bookingHeader: {
+    backgroundColor: Colors.accentColor,
+    color: Colors.cardBackground,
+    marginBottom: 5,
+    padding: 20,
+    ...Shadow(2),
+  },
+  bookingList: {
+    marginTop: 20,
+  },
+  cardHeader: {
+    borderBottomColor: Colors.dividerLine,
+    borderBottomWidth: 0.5,
+    marginBottom: 5,
+    paddingBottom: 5,
   },
   container: {
     flex: 1,
@@ -39,23 +57,10 @@ const styles = StyleSheet.create({
     marginTop: 20,
   },
   equipmentList: {
+    backgroundColor: Colors.cardBackground,
     marginTop: 20,
-    backgroundColor: 'white',
     padding: 20,
-    elevation: 2,
-  },
-  cardHeader: {
-    paddingBottom: 5,
-    marginBottom: 5,
-    borderBottomColor: 'grey',
-    borderBottomWidth: 0.5,
-  },
-  bookingHeader: {
-    padding: 20,
-    marginBottom: 5,
-    backgroundColor: '#1B998B',
-    color: 'white',
-    elevation: 2,
+    ...Shadow(2),
   },
   padder: {
     height: 20,
@@ -228,7 +233,9 @@ class RoomDetailScreen extends Component {
           ) : null}
           {equipment.length > 0 ? (
             <View style={styles.equipmentList}>
-              <SubtitleText style={styles.cardHeader}>In This Room</SubtitleText>
+              <SubtitleText style={styles.cardHeader}>
+                In This Room
+              </SubtitleText>
               {equipment.map(this.renderEquipment)}
             </View>
           ) : null}
@@ -239,7 +246,9 @@ class RoomDetailScreen extends Component {
           ) : null}
           {roombookings.length > 0 ? (
             <View style={styles.bookingList}>
-              <SubtitleText style={styles.bookingHeader}>Bookings Today</SubtitleText>
+              <SubtitleText style={styles.bookingHeader}>
+                Bookings Today
+              </SubtitleText>
               {roombookings.map(this.renderBooking)}
             </View>
           ) : null}


### PR DESCRIPTION
Solves #26, added some aesthetic material design-esque cards to this - 2 issues:
1) Room Capacities aren't showing
2) Untested on iOS

![image](https://user-images.githubusercontent.com/23053319/53374323-e2b19800-394f-11e9-9a5c-9a6507cf5249.png)
![image](https://user-images.githubusercontent.com/23053319/53374348-ee9d5a00-394f-11e9-9cdc-a6837a71d205.png)

Note: not on published on expo yet



