### PR TITLE
Happening Now indicator for classes

### DIFF
--- a/components/Button/FloatingHeartButton/FloatingHeartButton.js
+++ b/components/Button/FloatingHeartButton/FloatingHeartButton.js
@@ -17,13 +17,16 @@ class FloatingHeartButton extends Component {
     onPress: () => {},
   };
 
-  renderIcon = () => (
-    <Entypo
-      name={this.props.active ? "heart" : "heart-outlined"}
-      size={24}
-      color={this.props.active ? Colors.errorColor : Colors.pageBackground}
-    />
-  );
+  renderIcon = () => {
+    const { active } = this.props;
+    return (
+      <Entypo
+        name={active ? "heart" : "heart-outlined"}
+        size={24}
+        color={active ? Colors.errorColor : Colors.pageBackground}
+      />
+    );
+  };
 
   render() {
     const { active, onPress } = this.props;

--- a/components/Card/TimetableCard.js
+++ b/components/Card/TimetableCard.js
@@ -1,9 +1,21 @@
 import React, { Fragment } from "react";
+import { StyleSheet } from "react-native";
 import PropTypes from "prop-types";
 import { Feather } from "@expo/vector-icons";
 import moment from "moment";
-import Card from "./";
+import Card from ".";
 import { BodyText } from "../Typography";
+import LiveIndicator from "../LiveIndicator";
+import { Horizontal } from "../Containers";
+
+const styles = StyleSheet.create({
+  nowIndicator: {
+    marginLeft: 10,
+  },
+  timeContainer: {
+    justifyContent: "flex-start",
+  },
+});
 
 const TimetableCard = ({
   moduleName,
@@ -17,12 +29,13 @@ const TimetableCard = ({
 }) => {
   const start = moment(startTime).format("HH:mma");
   const end = moment(endTime).format("HH:mma");
+  const happeningNow =
+    moment().isSameOrAfter(startTime) && moment().isSameOrBefore(endTime);
   return (
     <Card
       old={pastEvent}
       title={moduleCode}
       onPress={() => {
-        console.log("Attempting to navigate...");
         navigation.navigate("TimetableDetail", {
           date: moment(startTime).format("YYYY-MM-DD"),
           time: moment(startTime).format("HH:mm"),
@@ -32,9 +45,14 @@ const TimetableCard = ({
       }}
     >
       <BodyText>{moduleName}</BodyText>
-      <BodyText>
-        <Feather name="clock" /> {start} - {end}
-      </BodyText>
+      <Horizontal style={styles.timeContainer}>
+        <BodyText>
+          <Feather name="clock" /> {start} - {end}
+        </BodyText>
+        {happeningNow ? (
+          <LiveIndicator style={styles.nowIndicator}>Now</LiveIndicator>
+        ) : null}
+      </Horizontal>
       {!pastEvent && (
         <Fragment>
           <BodyText>

--- a/components/LiveIndicator.js
+++ b/components/LiveIndicator.js
@@ -1,16 +1,17 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { ViewPropTypes } from "react-native";
 import { LinearGradient } from "expo";
-import { BodyText } from "../../components/Typography";
-import Colors from "../../constants/Colors";
-import Style from "../../styles/Containers";
+import { BodyText } from "./Typography";
+import Colors from "../constants/Colors";
+import Style from "../styles/Containers";
 
-const LiveIndicator = ({ children }) => (
+const LiveIndicator = ({ children, style }) => (
   <LinearGradient
     colors={[Colors.errorColor, Colors.indicatorOrange]}
     start={[0, 1]}
     end={[1, 0]}
-    style={Style.liveIndicator}
+    style={[Style.liveIndicator, style]}
   >
     <BodyText style={{ color: Colors.pageBackground }}>{children}</BodyText>
   </LinearGradient>
@@ -18,10 +19,12 @@ const LiveIndicator = ({ children }) => (
 
 LiveIndicator.propTypes = {
   children: PropTypes.string,
+  style: ViewPropTypes.style,
 };
 
 LiveIndicator.defaultProps = {
   children: "LIVE",
+  style: {},
 };
 
 export default LiveIndicator;

--- a/constants/Colors.js
+++ b/constants/Colors.js
@@ -9,7 +9,7 @@ export default {
   dividerLine: "#808080",
   oldCardBackground: "#f2f2f2",
   buttonBackground: "#4BB3FD",
-  disabledButtonBackground: "rgba(152, 153, 160, 1)",
+  disabledButtonBackground: "rgba(231, 231, 233, 1)",
   errorColor: "rgba(215, 38, 61, 1)",
   warningColor: "#AB7627",
   infoColor: "#1C5C8A",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8874,8 +8874,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -10230,7 +10229,7 @@
         "qs": "^6.5.0",
         "react-native-branch": "2.2.5",
         "react-native-gesture-handler": "~1.0.14",
-        "react-native-maps": "github:expo/react-native-maps#v0.22.1-exp.0",
+        "react-native-maps": "github:expo/react-native-maps#e6f98ff7272e5d0a7fe974a41f28593af2d77bb2",
         "react-native-reanimated": "1.0.0-alpha.11",
         "react-native-screens": "1.0.0-alpha.22",
         "react-native-svg": "8.0.10",
@@ -11568,8 +11567,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -11587,13 +11585,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11606,18 +11602,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11720,8 +11713,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11731,7 +11723,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11744,20 +11735,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -11774,7 +11762,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11847,8 +11834,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11858,7 +11844,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11934,8 +11919,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11965,7 +11949,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11983,7 +11966,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -12022,13 +12004,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -23444,15 +23424,13 @@
           "version": "2.17.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
           "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -24545,8 +24523,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "wide-align": {
       "version": "1.1.3",

--- a/screens/SettingsScreen/SettingsScreen.js
+++ b/screens/SettingsScreen/SettingsScreen.js
@@ -24,7 +24,7 @@ import Button, { SmallButton } from "../../components/Button";
 import Colors from "../../constants/Colors";
 import TextInput from "../../components/Input/TextInput";
 import NotificationSwitch from "./NotificationSwitch";
-import LiveIndicator from "../StudySpaceDetailScreen/LiveIndicator";
+import LiveIndicator from "../../components/LiveIndicator";
 import common from "../../styles/common";
 
 const { version } = require("../../package.json");

--- a/screens/StudySpaceDetailScreen/CapacityChart/CapacityChart.js
+++ b/screens/StudySpaceDetailScreen/CapacityChart/CapacityChart.js
@@ -90,7 +90,8 @@ class CapacityChart extends Component {
   };
 
   componentDidUpdate(prevProps) {
-    if (prevProps.loading && !this.props.loading) {
+    const { loading } = this.props;
+    if (prevProps.loading && !loading) {
       setTimeout(() => this.setState({ showData: true }), 600);
     }
   }
@@ -143,27 +144,18 @@ class CapacityChart extends Component {
               extras={[Gradient, line, highlightBar]}
             />
             <XAxis
-              style={{ marginHorizontal: -10 }}
-              contentInset={{ top: 10, right: 15 }}
+              style={{ marginHorizontal: -10, marginTop: 10 }}
+              contentInset={{ right: 15 }}
               data={
                 showData
                   ? Object.keys(graphData).map(v => Number.parseInt(v, 10))
                   : []
               }
               formatLabel={this.formatXLabel}
-              svg={{ y: 10, fontSize: 16, fill: "black" }}
+              svg={{ fontSize: 16, fill: "black" }}
             />
           </React.Fragment>
         )}
-        {/* <Horizontal
-          style={{ justifyContent: "space-between", paddingHorizontal: 2 }}
-        >
-          <BodyText style={TextStyles.small}>12:00 am</BodyText>
-          <BodyText style={TextStyles.small}>6:00 am</BodyText>
-          <BodyText style={TextStyles.small}>12:00 pm</BodyText>
-          <BodyText style={TextStyles.small}>6:00 pm</BodyText>
-          <BodyText style={TextStyles.small}>11:00 pm</BodyText>
-        </Horizontal> */}
       </View>
     );
   }

--- a/screens/StudySpaceDetailScreen/StudySpaceDetailScreen.js
+++ b/screens/StudySpaceDetailScreen/StudySpaceDetailScreen.js
@@ -8,7 +8,7 @@ import { fetchAverages } from "../../actions/studyspacesActions";
 import { Page, Horizontal } from "../../components/Containers";
 import { BodyText, TitleText, SubtitleText } from "../../components/Typography";
 import CapacityChart from "./CapacityChart";
-import LiveIndicator from "./LiveIndicator";
+import LiveIndicator from "../../components/LiveIndicator";
 // import OpeningHours from "./OpeningHours";
 import FavouriteButton from "./FavouriteButton";
 import LiveSeatingMapList from "./LiveSeatingMapList";

--- a/screens/StudySpaceDetailScreen/StudySpaceDetailScreen.js
+++ b/screens/StudySpaceDetailScreen/StudySpaceDetailScreen.js
@@ -20,8 +20,9 @@ const busyText = (
   capacity = 1,
 ) => {
   const diff = data[time] - occupied;
-  if (Math.abs(diff) / capacity < 0.05) {
-    return "about as busy as normal";
+  const threshold = capacity > 100 ? 0.1 : 0.05;
+  if (Math.abs(diff) / capacity < threshold) {
+    return "as busy as normal";
   }
   if (diff > 0) {
     return "quieter than usual";
@@ -38,8 +39,11 @@ const styles = StyleSheet.create({
     marginTop: 10,
   },
   liveIndicator: {
+    marginRight: 10,
+  },
+  liveIndicatorContainer: {
     justifyContent: "flex-start",
-    marginBottom: 10,
+    paddingRight: 40,
   },
   occupancySection: {
     flex: 1,
@@ -48,7 +52,7 @@ const styles = StyleSheet.create({
     height: 80,
   },
   popularTimes: {
-    marginVertical: 10,
+    marginTop: 10,
   },
 });
 
@@ -160,8 +164,8 @@ class StudySpaceDetailScreen extends Component {
               loading={isFetchingAverages}
             />
           </View>
-          <Horizontal style={styles.liveIndicator}>
-            <LiveIndicator />
+          <Horizontal style={styles.liveIndicatorContainer}>
+            <LiveIndicator style={styles.liveIndicator} />
             <BodyText>
               {moment().format("h:mma")} -{" "}
               {busyText(hour, data, occupied, total)}

--- a/screens/TimetableScreen/TimetableComponent.js
+++ b/screens/TimetableScreen/TimetableComponent.js
@@ -17,7 +17,7 @@ const mapToCards = (timetableItems, date, navigation, past = false) =>
       endTime={`${date} ${item.end_time}`}
       location={item.location.name || "TBA"}
       lecturer={item.contact ? item.contact : "Unknown Lecturer"}
-      pastEvent={past}
+      pastEvent={false}
       key={generate()}
       navigation={navigation}
     />

--- a/screens/TimetableScreen/TimetableComponent.js
+++ b/screens/TimetableScreen/TimetableComponent.js
@@ -17,7 +17,7 @@ const mapToCards = (timetableItems, date, navigation, past = false) =>
       endTime={`${date} ${item.end_time}`}
       location={item.location.name || "TBA"}
       lecturer={item.contact ? item.contact : "Unknown Lecturer"}
-      pastEvent={false}
+      pastEvent={past}
       key={generate()}
       navigation={navigation}
     />


### PR DESCRIPTION
As suggested in #112.

<img src="https://user-images.githubusercontent.com/6523121/54869579-9d3b8b80-4d92-11e9-898a-d6d155c89d03.jpg" width="200" />

The event will remain in the upcoming events section (not the past events section). This is because it's not over yet.

Also resolved:

* Busyness label does not wrap #114
* Study Spaces Graph Needs a Taller Text Container for X Axis Labels #113

[https://exp.host/@uclapi/ucl-assistant?release-channel=dev.feature.happening_now](https://exp.host/@uclapi/ucl-assistant?release-channel=dev.feature.happening_now)