### PR TITLE
Fixes app.example.json with some new fields

### DIFF
--- a/app.example.json
+++ b/app.example.json
@@ -5,7 +5,8 @@
     "slug": "ucl-assistant",
     "privacy": "public",
     "sdkVersion": "32.0.0",
-    "version": "0.6.5",
+    "version": "1.1.0",
+    "githubUrl": "https://github.com/uclapi/ucl-assistant-app",
     "orientation": "portrait",
     "primaryColor": "#1B998B",
     "icon": "./assets/images/icon.png",
@@ -28,15 +29,17 @@
         "googleMaps": {
           "apiKey": "<change-me>"
         }
-      }
+      },
+      "versionCode": 2,
+      "playStoreUrl": "https://play.google.com/store/apps/details?id=com.uclapi.uclassistant"
     },
     "hooks": {
       "postPublish": [
         {
           "file": "sentry-expo/upload-sourcemaps",
           "config": {
-            "organization": "matt-bell",
-            "project": "ucl-assistant-server",
+            "organization": "example-organisation",
+            "project": "ucl-assistant-app",
             "authToken": "<change-me>"
           }
         }


### PR DESCRIPTION
I've added some fixes to the app.example.json file that our app.json is based on. The most important change is the versionCode field: this is necessary to get new APKs published on the Play Store.

https://docs.expo.io/versions/v32.0.0/workflow/configuration/#versioncode

Other changes are minor :)