### PR TITLE
Upload command for developer convenience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ yarn.lock
 .tmp
 .DS_Store
 *.rej
+
+android.json
+ios.json

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ To build a APK/IPA, which will also publish the current version of UCL Assistant
 $ npm run build
 ```
 
+To upload the APK/IPA to the Play/App Store.
+
+```
+$ npm run upload
+```
+
+When uploading to the Play Store, there should be an `android.json` containing the credentials for the service account in the project root folder. This is the credentials JSON file that can be obtained from the [Google Developers Console](https://console.developers.google.com/project/685091039853/apiui/credential) (see `android.example.json`).
+
+When uploading to the App Store, there should be an `ios.json` containing the credentials for the App Store Connect account (see `ios.example.json`).
+
 ### Details
 
 Expo allows us to update the app seamlessly OTA.

--- a/android.example.json
+++ b/android.example.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "api-727498237492837-938420394",
+  "private_key_id": "8dfdf8sdf7sdfsdfsd8f7sd8f7sd",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMHUGYUFGFYUDGSFGDSGFYUGjhhgyugYUFUFUF\n-----END PRIVATE KEY-----\n",
+  "client_email": "ucl-assistant@api-9148394072347-4832483294.iam.gserviceaccount.com",
+  "client_id": "2839740927498237423",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/ucl-assistant@api-9148394072347-4832483294.iam.gserviceaccount.com"
+}

--- a/ios.example.json
+++ b/ios.example.json
@@ -1,0 +1,4 @@
+{
+  "username": "you@apple.com",
+  "password": "verysecurepassword"
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "prestorybook": "rnstl",
     "start": "expo start",
     "publish": "node scripts/publish.js",
-    "build": "node scripts/build.js"
+    "build": "node scripts/build.js",
+    "upload": "node scripts/upload.js"
   },
   "dependencies": {
     "@expo/vector-icons": "^10.0.5",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -40,7 +40,9 @@ const run = async () => {
     version,
   } = await inquirer.prompt(questions)
 
-  const expoCommand = `node node_modules/.bin/expo build:${platform} --release-channel=${environment}-${version}`
+  const options = (platform === `android` ? `-t app-bundle` : ``)
+
+  const expoCommand = `node node_modules/.bin/expo build:${platform} ${options} --release-channel=${environment}-${version}`
 
   const confirmationQuestion = [{
     type: `confirm`,

--- a/scripts/upload.js
+++ b/scripts/upload.js
@@ -1,0 +1,93 @@
+const fs = require(`fs`)
+
+const {
+  spawn,
+} = require(`child_process`)
+
+const inquirer = require(`inquirer`)
+
+const run = async () => {
+  console.log(`This will upload the latest build of UCL Assistant to the Play or App Store (but will not automatically release the uploaded build)`)
+
+  const questions = [{
+    type: `list`,
+    name: `store`,
+    message: `Upload to which store?`,
+    choices: [{
+      name: `App Store (iOS)`,
+      value: `ios`,
+    }, {
+      name: `Play Store (Google Play)`,
+      value: `android`,
+    }],
+  },
+    /* {
+       type: `list`,
+       name: `action`,
+       message: `Upload which binary?`,
+       choices: [{
+         name: `Upload the latest build`,
+         value: `latest`,
+       },
+       {
+         name: `Upload a local build`,
+         value: `local`,
+       },
+       ],
+       when: ({
+         store,
+       }) => store === `android`,
+     } */
+  ]
+
+  const {
+    store,
+  } = await inquirer.prompt(questions)
+
+  let expoArgs
+
+  if (store === `android`) {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    if (!fs.existsSync(`android.json`)) {
+      return console.error(`android.json missing in project root`)
+    }
+    expoArgs = `--key android.json`
+  }
+  if (store === `ios`) {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    if (!fs.existsSync(`ios.json`)) {
+      return console.error(`ios.json missing in project root`)
+    }
+
+    const {
+      username,
+      password,
+    } = JSON.parse(fs.readFileSync(`ios.json`)) // eslint-disable-line security/detect-non-literal-fs-filename
+    expoArgs = `--apple-id ${username} --apple-id-password ${password}`
+  }
+
+  const expoCommand = `expo upload:${store} ${expoArgs}`
+
+  const confirmationQuestion = [{
+    type: `confirm`,
+    // eslint-disable-next-line no-secrets/no-secrets
+    name: `uploadCommandCorrect`,
+    message: `The following command will now be run: ${expoCommand}`,
+    default: false,
+  }]
+
+  const {
+    uploadCommandCorrect,
+  } = await inquirer.prompt(confirmationQuestion)
+
+  if (!uploadCommandCorrect) {
+    return console.error(`Wrong command => stopped`)
+  }
+
+  const [command, ...args] = expoCommand.split(` `)
+  return spawn(command, args, {
+    stdio: `inherit`,
+  })
+}
+
+run()


### PR DESCRIPTION
Added script to upload binaries to the Play / App Stores on `npm run upload`

Can possibly combine `npm run build` and `npm run upload` in the future.