### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "semver:minor"
+      - match:
+          dependency_type: "production"
+          update_type: "semver:patch"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -16,4 +16,8 @@ update_configs:
       - match:
           dependency_name: "react"
       - match:
+          dependency_name: "react-dom"
+      - match:
           dependency_name: "react-native*"
+      - match:
+          dependency_name: "lottie-react-native"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,3 +10,10 @@ update_configs:
       - match:
           dependency_type: "production"
           update_type: "semver:patch"
+    ignored_updates:
+      - match:
+          dependency_name: "babel-core"
+      - match:
+          dependency_name: "react"
+      - match:
+          dependency_name: "react-native*"


### PR DESCRIPTION
Automerge updates in the following scenarios:

* If the dependency is a development dependency (i.e. a linting or testing library), and the update is a minor update
* If the dependency is a production dependency (any other library, e.g. expo, react-native, redux), and the update is a patch update

Automerging will only occur if all checks pass, and only during working hours (1000hrs-1700hrs from Mon-Fri)

