### PR TITLE
Add feedback button

### DIFF
--- a/lib/AnalyticsManager.js
+++ b/lib/AnalyticsManager.js
@@ -35,6 +35,12 @@ const logEvent = (eventName, eventProperties) => {
 
 const logScreenView = (screenName) => logEvent(`VIEW_SCREEN_${screenName}`)
 
+const events = {
+  SETTINGS_GIVE_FEEDBACK: `SETTINGS_GIVE_FEEDBACK`,
+  SETTINGS_RATE_APP: `SETTINGS_RATE_APP`,
+  SETTINGS_VIEW_FAQS: `SETTINGS_VIEW_FAQS`,
+}
+
 const AnalyticsManager = {
   initialise,
   setUserId,
@@ -42,6 +48,7 @@ const AnalyticsManager = {
   clearUserProperties,
   logEvent,
   logScreenView,
+  events,
 }
 
 export default (AMPLITUDE_API_KEY && !__DEV__)


### PR DESCRIPTION
Feedback button on Settings screen opens the user's email app, and prefills the `to`, `subject`, and the `body` field. The `body` field is pre-filled with debug info about the app, e.g. the device platform, the app release channel, the UPI, etc.

Resolves #76.