### PR TITLE
Fixed checkbox for iphones

### DIFF
--- a/__tests__/screens/SettingsScreen.test.js
+++ b/__tests__/screens/SettingsScreen.test.js
@@ -100,7 +100,7 @@ describe(`SettingsScreen`, () => {
     )
     expect(analyticsCheckbox.exists())
 
-    analyticsCheckbox.props().onValueChange(true)
+    analyticsCheckbox.props().onClick()
     expect(mockSetShouldTrackAnalytics).toHaveBeenCalledTimes(1)
     expect(mockSetShouldTrackAnalytics).toHaveBeenCalledWith(true)
   })

--- a/__tests__/screens/__snapshots__/SettingsScreen.test.js.snap
+++ b/__tests__/screens/__snapshots__/SettingsScreen.test.js.snap
@@ -88,15 +88,18 @@ exports[`SettingsScreen renders the SettingsScreen 1`] = `
       >
         Disallow UCL Assistant from sending analytics data to UCL API
       </BodyText>
-      <UnimplementedView
-        onValueChange={[Function]}
+      <CheckBox
+        isChecked={false}
+        isIndeterminate={false}
+        leftTextStyle={Object {}}
+        onClick={[Function]}
+        rightTextStyle={Object {}}
         style={
           Object {
             "flex": 0.1,
           }
         }
         testID="analyticsCheckbox"
-        value={false}
       />
     </View>
   </View>

--- a/__tests__/screens/__snapshots__/SettingsScreen.test.js.snap
+++ b/__tests__/screens/__snapshots__/SettingsScreen.test.js.snap
@@ -97,6 +97,7 @@ exports[`SettingsScreen renders the SettingsScreen 1`] = `
         style={
           Object {
             "flex": 0.1,
+            "justifyContent": "center",
           }
         }
         testID="analyticsCheckbox"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23716,6 +23716,14 @@
       "resolved": "https://registry.npmjs.org/react-native-branch/-/react-native-branch-3.0.1.tgz",
       "integrity": "sha512-vbcYxPZlpF5f39GAEUF8kuGQqCNeD3E6zEdvtOq8oCGZunHXlWlKgAS6dgBKCvsHvXgHuMtpvs39VgOp8DaKig=="
     },
+    "react-native-check-box": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-native-check-box/-/react-native-check-box-2.1.7.tgz",
+      "integrity": "sha512-dPVOoz4jKs2je2HSHp7+XJXNyZFq8Kij7IHutigrQKzB550Dko6ZAQu/1mG1FzdUMFxxkZ2nX59KmbR0Co0T8Q==",
+      "requires": {
+        "prop-types": "^15.5.7"
+      }
+    },
     "react-native-gesture-handler": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "react-moment-proptypes": "^1.7.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",
     "react-native-action-button": "^2.8.5",
+    "react-native-check-box": "^2.1.7",
     "react-native-gesture-handler": "~1.3.0",
     "react-native-maps": "~0.25.0",
     "react-native-modal-datetime-picker": "^7.5.0",

--- a/screens/SettingsScreen/SettingsScreen.js
+++ b/screens/SettingsScreen/SettingsScreen.js
@@ -6,13 +6,13 @@ import PropTypes from "prop-types"
 import React, { Component } from "react"
 import {
   Alert,
-  CheckBox,
   Clipboard,
   Linking,
   Platform,
   StyleSheet,
   View,
 } from "react-native"
+import CheckBox from 'react-native-check-box'
 import { NavigationActions, StackActions } from "react-navigation"
 import { connect } from "react-redux"
 
@@ -145,10 +145,10 @@ export class SettingsScreen extends Component {
     }
   }
 
-  toggleAnalytics = (value) => {
-    const { setShouldTrackAnalytics } = this.props
+  toggleAnalytics = () => {
+    const { user: { settings: { shouldTrackAnalytics: value } }, setShouldTrackAnalytics } = this.props
 
-    setShouldTrackAnalytics(value)
+    setShouldTrackAnalytics(!value)
   }
 
   signOut = () => {
@@ -251,8 +251,8 @@ export class SettingsScreen extends Component {
             <CheckBox
               testID="analyticsCheckbox"
               style={styles.settingsCheckBox}
-              value={user.settings.shouldTrackAnalytics}
-              onValueChange={this.toggleAnalytics}
+              isChecked={user.settings.shouldTrackAnalytics}
+              onClick={this.toggleAnalytics}
             />
           </View>
         </View>

--- a/screens/SettingsScreen/SettingsScreen.js
+++ b/screens/SettingsScreen/SettingsScreen.js
@@ -68,6 +68,7 @@ const styles = StyleSheet.create({
   },
   settingsCheckBox: {
     flex: 0.1,
+    justifyContent: `center`,
   },
   settingsText: {
     flex: 0.9,


### PR DESCRIPTION
* Changed checkbox from react native component which only works on android

* Changed to react: https://github.com/crazycodeboy/react-native-check-box

Have now tested and it is working as expected, the onClick doesnt pass a value so I had to change the toggleAnalytics function to updated the shouldTrack to the opposite of what it is currently i.e just toggle

If the tests pass it should be okay to merge