### PR TITLE
Fix alignment of graphic on TimetableScreen

### DIFF
--- a/screens/TimetableScreen/components/FreeWeek.js
+++ b/screens/TimetableScreen/components/FreeWeek.js
@@ -13,13 +13,13 @@ import Styles from "../../../styles/Containers"
 
 const styles = StyleSheet.create({
   container: {
-    alignItems: `center`,
     flex: 1,
     justifyContent: `center`,
     paddingBottom: 20,
     paddingTop: 20,
   },
   timetableImage: {
+    alignSelf: `center`,
     height: 200,
     marginTop: 5,
     width: 300,


### PR DESCRIPTION
On tablets and other large devices, the "free week" graphic was left-aligned instead of centre-aligned.

<img width="201" alt="Annotation 2020-03-11 132551" src="https://user-images.githubusercontent.com/6523121/76421944-59bfa000-639c-11ea-8e5f-bcec69179b0d.png">

This has now been fixed.

<img width="200" alt="Annotation 2020-03-11 132806" src="https://user-images.githubusercontent.com/6523121/76421948-5debbd80-639c-11ea-8ef9-8d9eae4d9ff6.png">
