### PR TITLE
Avoid showing out of date error for historical dates

### DIFF
--- a/__tests__/__snapshots__/App.test.tsx.snap
+++ b/__tests__/__snapshots__/App.test.tsx.snap
@@ -31,7 +31,6 @@ exports[`renders the root without loading screen 1`] = `
         style={
           Object {
             "flex": 1,
-            "overflow": "hidden",
           }
         }
       >
@@ -75,8 +74,8 @@ exports[`renders the root without loading screen 1`] = `
                     "damping": 500,
                     "mass": 3,
                     "overshootClamping": true,
-                    "restDisplacementThreshold": 0.01,
-                    "restSpeedThreshold": 0.01,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
                     "stiffness": 1000,
                   },
                 },
@@ -86,8 +85,8 @@ exports[`renders the root without loading screen 1`] = `
                     "damping": 500,
                     "mass": 3,
                     "overshootClamping": true,
-                    "restDisplacementThreshold": 0.01,
-                    "restSpeedThreshold": 0.01,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
                     "stiffness": 1000,
                   },
                 },
@@ -124,7 +123,7 @@ exports[`renders the root without loading screen 1`] = `
                   pointerEvents="none"
                   style={
                     Object {
-                      "backgroundColor": "#fff",
+                      "backgroundColor": "rgb(242, 242, 242)",
                       "bottom": 0,
                       "left": 0,
                       "position": "absolute",

--- a/screens/TimetableScreen/__tests__/LastModified.test.js
+++ b/screens/TimetableScreen/__tests__/LastModified.test.js
@@ -1,9 +1,10 @@
 /**
  * @jest-environment jsdom
  */
+import "react-native"
+
 import MockDate from 'mockdate'
 import React from 'react'
-import "react-native"
 import { cleanup, render } from "react-native-testing-library"
 
 import { LocalisationManager } from '../../../lib'
@@ -38,6 +39,18 @@ describe(`LastUpdated`, () => {
       lastModified: LocalisationManager
         .getMoment()
         .subtract(25, `hours`),
+    }
+    const wrapper = render(<LastModified {...mockProps} isLoading={false} />)
+    expect(wrapper.toJSON()).toMatchSnapshot()
+  })
+
+  it(`does not show error when data is more recent than date`, async () => {
+    const mockDate = `2019-09-08`
+    const mockProps = {
+      date: mockDate,
+      lastModified: LocalisationManager
+        .parseToMoment(mockDate)
+        .add(24, `hours`),
     }
     const wrapper = render(<LastModified {...mockProps} isLoading={false} />)
     expect(wrapper.toJSON()).toMatchSnapshot()

--- a/screens/TimetableScreen/__tests__/__snapshots__/LastModified.test.js.snap
+++ b/screens/TimetableScreen/__tests__/__snapshots__/LastModified.test.js.snap
@@ -2,6 +2,71 @@
 
 exports[`LastUpdated does not render if date is missing 1`] = `null`;
 
+exports[`LastUpdated does not show error when data is more recent than date 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "width": "100%",
+    }
+  }
+>
+  <View
+    accessible={true}
+    focusable={true}
+    isTVSelectable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "opacity": 1,
+      }
+    }
+  >
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#4D5061",
+            "fontFamily": "apercu",
+            "fontSize": 16,
+            "marginBottom": 1,
+            "marginTop": 1,
+          },
+          Object {
+            "color": "#2980b9",
+          },
+          Object {},
+        ]
+      }
+    >
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#6E707F",
+              "fontFamily": "apercu",
+              "fontSize": 16,
+              "marginBottom": 5,
+              "marginTop": 5,
+              "textAlign": "center",
+            },
+            Object {},
+          ]
+        }
+      >
+        Last updated 2 months ago
+      </Text>
+    </Text>
+  </View>
+</View>
+`;
+
 exports[`LastUpdated renders the LastUpdated component 1`] = `
 <View
   style={

--- a/screens/TimetableScreen/components/LastModified.js
+++ b/screens/TimetableScreen/components/LastModified.js
@@ -18,12 +18,14 @@ const styles = StyleSheet.create({
 
 class LastModified extends React.Component {
   static propTypes = {
+    date: PropTypes.string,
     isLoading: PropTypes.bool,
     lastModified: PropTypes.oneOfType([momentObj, PropTypes.string]),
     openFAQ: PropTypes.func,
   }
 
   static defaultProps = {
+    date: LocalisationManager.getMoment(),
     isLoading: true,
     lastModified: null,
     openFAQ: () => { },
@@ -37,15 +39,24 @@ class LastModified extends React.Component {
   )
 
   render() {
-    const { lastModified, openFAQ, isLoading } = this.props
+    const {
+      lastModified, openFAQ, isLoading, date,
+    } = this.props
 
     if (lastModified === null || typeof lastModified !== `object`) {
       return null
     }
 
-    const isStale = (!isLoading && lastModified.isBefore(
-      LocalisationManager.getMoment().subtract(24, `hour`),
-    ))
+    const isStale = (
+      !isLoading
+      && lastModified.isBefore(
+        LocalisationManager.getMoment().subtract(24, `hour`),
+      )
+      // not stale if the data is more recent than the date
+      && !lastModified.isAfter(
+        LocalisationManager.parseToMoment(date).endOf(`isoweek`),
+      )
+    )
 
     return (
       <View style={styles.lastModified}>
@@ -56,7 +67,7 @@ class LastModified extends React.Component {
               lastModified.isBefore()
                 ? lastModified.fromNow().toLowerCase()
                 : `just now`
-            }`}
+              }`}
           </CentredText>
         </Link>
       </View>

--- a/screens/TimetableScreen/components/WeekView.js
+++ b/screens/TimetableScreen/components/WeekView.js
@@ -143,6 +143,7 @@ class WeekView extends React.Component {
           lastModified={LocalisationManager.parseToMoment(lastModified)}
           openFAQ={this.openFAQ}
           isLoading={isLoading}
+          date={weekTimetable[0].dateISO}
         />
         {this.renderJumpToToday()}
       </View>


### PR DESCRIPTION
The app displayed an out of date error message on the TimetableScreen whenever the lastModified time was more than 24h ago. Since the lastModified time is not updated for historical timetable data, this meant that an out of date message would be displayed for any historical timetable data, even if the lastModified time was after the date of the timetable.

E.g. when viewing the timetable for 1st January 2020, with the current date being 22nd May 2020, even if the lastModified time was later than 1st January, say 5th January 2020 for instance, the out of date message would be displayed.

This PR fixes this by not displaying the error message if the lastModified time is more recent than the timetable data being viewed.